### PR TITLE
fix to document scroll not responding

### DIFF
--- a/css/css.css
+++ b/css/css.css
@@ -10,7 +10,11 @@ body, html {
 }
 html {
     height: 100%;
-    overflow: hidden;
+    /*overflow: hidden;*/
+}
+
+::-webkit-scrollbar {
+    width: 0;
 }
 
 /* Table */


### PR DESCRIPTION
What happened: gradient background on <tr> elements with a
background-attachement:fixed css rule prevents the scrolling to work
anymore if there is a css rule overflow:hidden on the root element (html
or body). Funny thing is that applying those css rules _after_ <tr>
elements have been drawn does not trigger the bug. Another workaround is
to set the overflow to auto or scroll. I chose the former solution and
set the scrollbar width to 0, thus having the possibility to scroll,
without having to deal with the ugliness of scrollbars
